### PR TITLE
fix: disable EIP-3541 check in anvil for Stylus contract deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "arbos-revm"
 version = "0.1.0"
-source = "git+https://github.com/iosiro/arbos-revm?rev=9b002b02c6f63cdf9047df67a337c2a3561fa0ce#9b002b02c6f63cdf9047df67a337c2a3561fa0ce"
+source = "git+https://github.com/iosiro/arbos-revm?rev=39794a701235cdb835efc185e3920ebd032f1bd6#39794a701235cdb835efc185e3920ebd032f1bd6"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,7 +220,7 @@ foundry-wallets = { path = "crates/wallets" }
 foundry-linking = { path = "crates/linking" }
 
 # arbos-revm
-arbos-revm = { git = "https://github.com/iosiro/arbos-revm", rev = "9b002b02c6f63cdf9047df67a337c2a3561fa0ce", default-features = false }
+arbos-revm = { git = "https://github.com/iosiro/arbos-revm", rev = "39794a701235cdb835efc185e3920ebd032f1bd6", default-features = false }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.22.0", default-features = false }

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1068,6 +1068,7 @@ impl NodeConfig {
         // If EIP-3607 is enabled it can cause issues during fuzz/invariant tests if the
         // caller is a contract. So we disable the check by default.
         cfg.inner.disable_eip3607 = true;
+        cfg.inner.disable_eip3541 = !self.stylus_config.disable_stylus_deployment;
         cfg.inner.disable_block_gas_limit = self.disable_block_gas_limit;
 
         if !self.enable_tx_gas_limit {

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -731,8 +731,7 @@ Warning: Key `deny_warnings` is being deprecated in favor of `deny = warnings`. 
 
 #[tokio::test]
 async fn ensure_lint_rule_docs() {
-    const FOUNDRY_BOOK_LINT_PAGE_URL: &str =
-        "https://book.getfoundry.sh/reference/forge/forge-lint";
+    const FOUNDRY_BOOK_LINT_PAGE_URL: &str = "https://book.getfoundry.sh/forge/linting";
 
     // Fetch the content of the lint reference
     let content = match reqwest::get(FOUNDRY_BOOK_LINT_PAGE_URL).await {
@@ -758,8 +757,11 @@ async fn ensure_lint_rule_docs() {
     // Ensure no missing lints
     let mut missing_lints = Vec::new();
     for lint in REGISTERED_LINTS {
-        let selector = format!("#{}", lint.id());
-        if !content.contains(&selector) {
+        let selector = lint.id().to_lowercase();
+        let selector_with_space = selector.replace("-", " ");
+        if !content.to_lowercase().contains(&selector)
+            && !content.to_lowercase().contains(&selector_with_space)
+        {
             missing_lints.push(lint.id());
         }
     }


### PR DESCRIPTION
Anvil was not applying the disable_eip3541 config from StylusConfig, causing eth_estimateGas and contract creation to reject Stylus bytecode starting with 0xEF (CreateContractStartingWithEF error).
