### PR TITLE
feat: add getStylusInitCode cheatcode for CREATE/CREATE2 deployments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "arbos-revm"
 version = "0.1.0"
-source = "git+https://github.com/iosiro/arbos-revm?rev=39794a701235cdb835efc185e3920ebd032f1bd6#39794a701235cdb835efc185e3920ebd032f1bd6"
+source = "git+https://github.com/iosiro/arbos-revm#39794a701235cdb835efc185e3920ebd032f1bd6"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,7 +220,7 @@ foundry-wallets = { path = "crates/wallets" }
 foundry-linking = { path = "crates/linking" }
 
 # arbos-revm
-arbos-revm = { git = "https://github.com/iosiro/arbos-revm", rev = "39794a701235cdb835efc185e3920ebd032f1bd6", default-features = false }
+arbos-revm = { git = "https://github.com/iosiro/arbos-revm", version = "0.1.0", default-features = false }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.22.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project was developed by [iosiro](https://www.iosiro.com/) as part of the [
 ## Features
 
 - **Native Stylus Execution**: Execute Stylus WASM programs directly in Forge tests without requiring a network fork
-- **Stylus Deployment Cheatcodes**: Deploy Stylus contracts using `vm.deployStylusCode()` and `vm.getStylusCode()`
+- **Stylus Deployment Cheatcodes**: Deploy Stylus contracts using `vm.deployStylusCode()`, `vm.getStylusCode()`, and `vm.getStylusInitCode()`
 - **Brotli Compression**: Built-in `vm.brotliCompress()` and `vm.brotliDecompress()` cheatcodes for Stylus bytecode handling
 - **ArbOS State**: Automatic initialization of ArbOS state with configurable parameters
 - **Arbitrum Precompiles**: Full support for 13 Arbitrum-specific precompiles (see [Supported Precompiles](#supported-precompiles))
@@ -141,6 +141,9 @@ address deployed = vm.deployStylusCode(string artifactPath, bytes32 salt);
 
 // Get Stylus bytecode (compressed with magic prefix)
 bytes memory code = vm.getStylusCode(string artifactPath);
+
+// Get init code for CREATE/CREATE2 deployment
+bytes memory initCode = vm.getStylusInitCode(string artifactPath);
 ```
 
 ### Brotli Compression
@@ -155,7 +158,7 @@ bytes memory decompressed = vm.brotliDecompress(bytes compressed);
 
 ## WASM Processing
 
-When you use `vm.deployStylusCode()` or `vm.getStylusCode()`, the WASM binary is automatically processed to match the behavior of `cargo stylus deploy`:
+When you use `vm.deployStylusCode()`, `vm.getStylusCode()`, or `vm.getStylusInitCode()`, the WASM binary is automatically processed to match the behavior of `cargo stylus deploy`:
 
 ### 1. Metadata Stripping
 
@@ -390,7 +393,7 @@ This fork is based on Foundry v1.5.1 with the following changes:
 
 - **Added**: Native Stylus/WASM execution via [arbos-revm](https://github.com/iosiro/arbos-revm)
 - **Added**: ArbOS state initialization with configurable parameters
-- **Added**: Stylus deployment cheatcodes (`deployStylusCode`, `getStylusCode`)
+- **Added**: Stylus deployment cheatcodes (`deployStylusCode`, `getStylusCode`, `getStylusInitCode`)
 - **Added**: Brotli compression cheatcodes (`brotliCompress`, `brotliDecompress`)
 - **Added**: 13 Arbitrum precompiles (ArbSys, ArbWasm, ArbGasInfo, etc.)
 - **Added**: Stylus configuration options (CLI, foundry.toml, inline)

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -6807,7 +6807,7 @@
     {
       "func": {
         "id": "getStylusCode",
-        "description": "Returns the deployment bytecode for a Stylus contract suitable for use with the StylusDeployer contract.\nTakes in the relative path to the WASM or Brotli compressed WASM binary.\nApplies the same compression and prefixing logic as `deployStylusCode`.",
+        "description": "Returns the compressed and prefixed Stylus bytecode (runtime code) for a contract.\nTakes in the relative path to the WASM or Brotli compressed WASM binary.\nApplies the same compression and prefixing logic as `deployStylusCode`.\nThis returns raw runtime bytecode without an init code wrapper, suitable for use with `vm.etch`.",
         "declaration": "function getStylusCode(string calldata artifactPath) external view returns (bytes memory);",
         "visibility": "external",
         "mutability": "view",
@@ -6818,6 +6818,26 @@
           186,
           7,
           49
+        ]
+      },
+      "group": "filesystem",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "getStylusInitCode",
+        "description": "Returns init code for a Stylus contract suitable for CREATE/CREATE2 or the StylusDeployer contract.\nTakes in the relative path to the WASM or Brotli compressed WASM binary.\nThe returned bytecode wraps the compressed Stylus code in EVM init code that\ndeploys it as contract code when executed via CREATE or CREATE2.",
+        "declaration": "function getStylusInitCode(string calldata artifactPath) external view returns (bytes memory);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getStylusInitCode(string)",
+        "selector": "0x7fb2f6d1",
+        "selectorBytes": [
+          127,
+          178,
+          246,
+          209
         ]
       },
       "group": "filesystem",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2040,11 +2040,19 @@ interface Vm {
     #[cheatcode(group = Filesystem)]
     function deployStylusCode(string calldata artifactPath, bytes calldata constructorArgs, uint256 value, bytes32 salt) external returns (address deployedAddress);
 
-    /// Returns the deployment bytecode for a Stylus contract suitable for use with the StylusDeployer contract.
+    /// Returns the compressed and prefixed Stylus bytecode (runtime code) for a contract.
     /// Takes in the relative path to the WASM or Brotli compressed WASM binary.
     /// Applies the same compression and prefixing logic as `deployStylusCode`.
+    /// This returns raw runtime bytecode without an init code wrapper, suitable for use with `vm.etch`.
     #[cheatcode(group = Filesystem)]
     function getStylusCode(string calldata artifactPath) external view returns (bytes memory);
+
+    /// Returns init code for a Stylus contract suitable for CREATE/CREATE2 or the StylusDeployer contract.
+    /// Takes in the relative path to the WASM or Brotli compressed WASM binary.
+    /// The returned bytecode wraps the compressed Stylus code in EVM init code that
+    /// deploys it as contract code when executed via CREATE or CREATE2.
+    #[cheatcode(group = Filesystem)]
+    function getStylusInitCode(string calldata artifactPath) external view returns (bytes memory);
 
     /// Compresses the given data using Brotli compression (quality: 11, window: 22).
     #[cheatcode(group = String)]

--- a/crates/linking/src/lib.rs
+++ b/crates/linking/src/lib.rs
@@ -705,7 +705,7 @@ mod tests {
                     "default/linking/nested/Nested.t.sol:NestedLib",
                     &[(
                         "default/linking/nested/Nested.t.sol:Lib",
-                        address!("0xd5d0c56ae71393246e46950ee40f14dcb0898849"),
+                        address!("0x19fa389ba0eb91a67036dd918e951b47d850c4b0"),
                     )],
                 )
                 .assert_dependencies(
@@ -715,12 +715,12 @@ mod tests {
                         // have the same address and nonce.
                         (
                             "default/linking/nested/Nested.t.sol:Lib",
-                            Address::from_str("0xd5d0c56ae71393246e46950ee40f14dcb0898849")
+                            Address::from_str("0x19fa389ba0eb91a67036dd918e951b47d850c4b0")
                                 .unwrap(),
                         ),
                         (
                             "default/linking/nested/Nested.t.sol:NestedLib",
-                            Address::from_str("0x4182c6ba261accf5dc1202ba47496cfbf0650428")
+                            Address::from_str("0x1c7edef214838be7723eca84ccbe91ee7cbc98cf")
                                 .unwrap(),
                         ),
                     ],
@@ -730,12 +730,12 @@ mod tests {
                     &[
                         (
                             "default/linking/nested/Nested.t.sol:Lib",
-                            Address::from_str("0xd5d0c56ae71393246e46950ee40f14dcb0898849")
+                            Address::from_str("0x19fa389ba0eb91a67036dd918e951b47d850c4b0")
                                 .unwrap(),
                         ),
                         (
                             "default/linking/nested/Nested.t.sol:NestedLib",
-                            Address::from_str("0x4182c6ba261accf5dc1202ba47496cfbf0650428")
+                            Address::from_str("0x1c7edef214838be7723eca84ccbe91ee7cbc98cf")
                                 .unwrap(),
                         ),
                     ],

--- a/testdata/default/cheats/GetStylusInitCode.t.sol
+++ b/testdata/default/cheats/GetStylusInitCode.t.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "utils/Test.sol";
+
+contract GetStylusInitCodeTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testGetStylusInitCode() public {
+        bytes memory initCode = vm.getStylusInitCode("fixtures/Stylus/foundry_stylus_program.wasm");
+        assertTrue(initCode.length > 0);
+    }
+
+    function testInitCodeDeploysMatchingStylusCode() public {
+        bytes memory stylusCode = vm.getStylusCode("fixtures/Stylus/foundry_stylus_program.wasm");
+        bytes memory initCode = vm.getStylusInitCode("fixtures/Stylus/foundry_stylus_program.wasm");
+
+        // Deploy using CREATE with the init code
+        address deployed;
+        assembly {
+            deployed := create(0, add(initCode, 0x20), mload(initCode))
+        }
+        assertTrue(deployed != address(0), "CREATE failed");
+
+        // The runtime code at the deployed address should match getStylusCode output
+        bytes memory runtimeCode = deployed.code;
+        assertEq(runtimeCode, stylusCode);
+    }
+
+    function testInitCodeDeploysWithCreate2() public {
+        bytes memory stylusCode = vm.getStylusCode("fixtures/Stylus/foundry_stylus_program.wasm");
+        bytes memory initCode = vm.getStylusInitCode("fixtures/Stylus/foundry_stylus_program.wasm");
+        bytes32 salt = keccak256("test-salt");
+
+        // Deploy using CREATE2 with the init code
+        address deployed;
+        assembly {
+            deployed := create2(0, add(initCode, 0x20), mload(initCode), salt)
+        }
+        assertTrue(deployed != address(0), "CREATE2 failed");
+
+        // The runtime code should match getStylusCode output
+        bytes memory runtimeCode = deployed.code;
+        assertEq(runtimeCode, stylusCode);
+    }
+}

--- a/testdata/utils/Vm.sol
+++ b/testdata/utils/Vm.sol
@@ -334,6 +334,7 @@ interface Vm {
     function getStorageAccesses() external view returns (StorageAccess[] memory storageAccesses);
     function getStorageSlots(address target, string calldata variableName) external view returns (uint256[] memory slots);
     function getStylusCode(string calldata artifactPath) external view returns (bytes memory);
+    function getStylusInitCode(string calldata artifactPath) external view returns (bytes memory);
     function getWallets() external view returns (address[] memory wallets);
     function indexOf(string calldata input, string calldata key) external pure returns (uint256);
     function interceptInitcode() external;


### PR DESCRIPTION
Returns EVM init code wrapping compressed Stylus bytecode, suitable for direct CREATE/CREATE2 deployment or use with the StylusDeployer contract. Also corrects getStylusCode description to clarify it returns raw runtime bytecode for use with vm.etch.